### PR TITLE
Add Album display_artists test

### DIFF
--- a/test/fixtures/album_artists.yml
+++ b/test/fixtures/album_artists.yml
@@ -1,0 +1,6 @@
+album_artist_one:
+  album: sample_album
+  artist: john
+album_artist_two:
+  album: sample_album
+  artist: paul

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,0 +1,2 @@
+sample_album:
+  title: Sample Album

--- a/test/fixtures/artists.yml
+++ b/test/fixtures/artists.yml
@@ -1,0 +1,4 @@
+john:
+  name: John
+paul:
+  name: Paul

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class AlbumTest < ActiveSupport::TestCase
+  fixtures :albums, :artists, :album_artists
+
+  test "#display_artists returns a comma-separated string of artist names" do
+    album = albums(:sample_album)
+    assert_equal "John, Paul", album.display_artists
+  end
+end


### PR DESCRIPTION
## Summary
- add fixtures for albums, artists, and album_artists
- test Album#display_artists returns comma separated artist names

## Testing
- `bin/rails test test/models/album_test.rb -v` *(fails: rbenv: version `3.3.5` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f4044629c83218164a91114395f8f